### PR TITLE
Added try/catch block to prevent race condition with hidden elements …

### DIFF
--- a/blockadblock.js
+++ b/blockadblock.js
@@ -154,9 +154,13 @@
 			detected = true;
 		}
 		if(window.getComputedStyle !== undefined) {
-			var baitTemp = window.getComputedStyle(this._var.bait, null);
-			if(baitTemp && (baitTemp.getPropertyValue('display') == 'none' || baitTemp.getPropertyValue('visibility') == 'hidden')) {
-				detected = true;
+			try {
+				var baitTemp = window.getComputedStyle(this._var.bait, null);
+				if(baitTemp && (baitTemp.getPropertyValue('display') == 'none' || baitTemp.getPropertyValue('visibility') == 'hidden')) {
+					detected = true;
+				}
+			} catch(e) {
+				this._log('_checkBait', 'Error in getting computed style ' + e);
 			}
 		}
 		


### PR DESCRIPTION
…in rare cases.

We found that Firefox can be a little slow sometimes and when the target page is within an IFrame, which will be hidden by the frontend (after page load), this can cause a race condition during which getComputedStyle is failing to retrieve any data.
In this case, trying to access properties on baitTemp will fail and break the JavaScript execution. A try/catch block prevents this and doesn't seem to do any harm for the detection.

I realise that this is pretty much an edge case, but we have found this to repeatedly happen (for this specific scenario) in our production environment.