### PR TITLE
Fixed issue on adblock detecting on unix devices - case sensitive

### DIFF
--- a/blockadblock.js
+++ b/blockadblock.js
@@ -241,8 +241,8 @@
 	
 	window.BlockAdBlock = BlockAdBlock;
 	
-	if(window.blockAdBlock === undefined) {
-		window.blockAdBlock = new BlockAdBlock({
+	if(window.BlockAdBlock === undefined) {
+		window.BlockAdBlock = new BlockAdBlock({
 			checkOnLoad: true,
 			resetOnEnd: true
 		});


### PR DESCRIPTION
The script is not working on iOS Devices because the window Parameters are case sensitive.

The Pull request fixes the detection on iOS